### PR TITLE
Add ch-apache build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-weblogic
-Provides builds for ch-oraclelinux, ch-serverjre and ch-weblogic images
+Provides builds for ch-oraclelinux, ch-serverjre, ch-weblogic and ch-apache images
 
 
 ## ch-oraclelinux
@@ -13,7 +13,8 @@ To build the image, from the root of the repo run:
 This build extends the ch-oraclelinux image to install the Oracle Java Server JRE 8.  
 
 The JRE needs to be downloaded separately from Oracle, as it is a licensed product, and can be obtained from https://www.oracle.com/java/technologies/javase-server-jre8-downloads.html. Select the Linux 64bit version with a name that follows the pattern `server-jre-8uNNN-linux-x64.tar.gz`, where NNN is the minor version.  The latest version at the time of writing is `server-jre-8u271-linux-x64.tar.gz`
-Place the downloaded JRE inside the `ch-oraclelinux` folder before building.
+
+Place the downloaded JRE inside the `ch-oraclelinux` directory before building.
 
 To build the image, from the root of the repo run:
 
@@ -26,7 +27,7 @@ The WebLogic server installation and PSU need to be downloaded separately from O
 The WebLogic installation can be obtained from http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-for-dev-1703574.html.  Select the generic installer for 12.1.3 `fmw_12.1.3.0.0_wls.jar`, as that can be used for production.  
 The PSU can be obtained from Oracle support https://support.oracle.com/epmos/faces/DocumentDisplay?id=2694898.1 The required patch file is `p31656851_121300_Generic.zip`.
 
-Place the two downloaded files, inside the `ch-weblogic` folder before building.
+Place the two downloaded files, inside the `ch-weblogic` directory before building.
 
 To build the image, from the root of the repo run:
 
@@ -35,3 +36,17 @@ To build the image, from the root of the repo run:
 This build will result in a large image ~ 4GB in size.  To reduce the size down to a more manageable ~1.2GB, you can use the experimental `--squash` flag when running the build.  To use this, you will need to enable experimental features for the docker client.
 
     docker build -t ch-weblogic --squash ch-weblogic/
+
+## ch-apache
+This build extends the official httpd:2.4 Apache image, https://hub.docker.com/_/httpd/, with the WebLogic Apache plugin 12.2.1.4.0.
+
+The WebLogic Apache plugin needs to be downloaded manually from Oracle, as it is a licensed product.  The installation files can be obtained from https://www.oracle.com/uk/middleware/technologies/webtier-downloads.html
+
+Place the downloaded `fmw_12.2.1.4.0_wlsplugins_Disk1_1of1.zip` file inside the ch-apache directory, prior to building, and then:
+ - unzip the `fmw_12.2.1.4.0_wlsplugins_Disk1_1of1.zip` file
+ - unzip the `WLSPlugins12c-12.2.1.4.0.zip` file
+ - unzip the `WLSPlugin12.2.1.4.0-Apache2.2-Apache2.4-Linux_x86_64-12.2.1.4.0.zip` file
+
+To build the image, from the root of the repo run:
+
+    docker build -t ch-apache ch-apache/

--- a/ch-apache/Dockerfile
+++ b/ch-apache/Dockerfile
@@ -1,0 +1,10 @@
+FROM httpd:2.4
+
+ENV PLUGIN_PATH=modules/WLSPlugin12.2.1.4.0
+ENV LD_LIBRARY_PATH=${HTTPD_PREFIX}/${PLUGIN_PATH}
+
+# Copy the WebLogic Apache plugin module and libs onto the image   
+COPY lib ${PLUGIN_PATH}
+
+# Reference the plugin module
+RUN sed -i '/mod_rewrite.so$/a LoadModule weblogic_module modules\/WLSPlugin12.2.1.4.0\/mod_wl_24.so' conf/httpd.conf


### PR DESCRIPTION
Adds a ch-apache Dockerfile that extends the official httpd:2.4 Apache image (https://hub.docker.com/_/httpd/) with the WebLogic Apache plugin 12.2.1.4.0

There will be an additional PR which creates a cic-apache build that will further extend the ch-apache image with the configuration that is specific to the CIC application, along with the deployment of the application's static content.

Resolves:
CM-301 