### PR TITLE
Add start script for apache

### DIFF
--- a/ch-apache/Dockerfile
+++ b/ch-apache/Dockerfile
@@ -6,5 +6,11 @@ ENV LD_LIBRARY_PATH=${HTTPD_PREFIX}/${PLUGIN_PATH}
 # Copy the WebLogic Apache plugin module and libs onto the image   
 COPY lib ${PLUGIN_PATH}
 
+# Use a custom start script to allow creation of exportedlogs/apache directory before startup
+COPY start-apache.sh bin/start-apache.sh
+RUN chmod +x bin/start-apache.sh
+
 # Reference the plugin module
 RUN sed -i '/mod_rewrite.so$/a LoadModule weblogic_module modules\/WLSPlugin12.2.1.4.0\/mod_wl_24.so' conf/httpd.conf
+
+CMD ["/usr/local/apache2/bin/start-apache.sh"]

--- a/ch-apache/start-apache.sh
+++ b/ch-apache/start-apache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# We want the logs to be stored in exportedlogs/apache instead of just logs
+# This has to be done at run time, as the exportedlogs folder is only mounted at that point
+mkdir -p /usr/local/apache2/exportedlogs/apache
+
+# Now start apache
+httpd-foreground


### PR DESCRIPTION
This creates a custom logging folder exportedlogs/apache at runtime.   This is needed as the exportedlogs location is mounted just before startup by docker.