### PR TITLE
Turn off WL proxy SSL flag if DISABLE_PROXY_SSL=true

### DIFF
--- a/ch-apache/start-apache.sh
+++ b/ch-apache/start-apache.sh
@@ -4,5 +4,10 @@
 # This has to be done at run time, as the exportedlogs folder is only mounted at that point
 mkdir -p /usr/local/apache2/exportedlogs/apache
 
+
+if [ "${DISABLE_PROXY_SSL}" = true ]; then
+  sed -i 's/WLProxySSL ON//g' /usr/local/apache2/conf/*.conf
+fi
+
 # Now start apache
 httpd-foreground


### PR DESCRIPTION
If the env var DISABLE_PROXY_SSL=true, then remove the `WLProxySSL ON` statements from the apache config files.
This allows CHIPS to function correctly when accessed without SSL, which is needed for the development environments.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1511