### PR TITLE
Reference version 1.2.2 of ch-serverjre to pull in new chca cert

### DIFF
--- a/ch-weblogic/Dockerfile
+++ b/ch-weblogic/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.0 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.2 as builder
 
 ENV ORACLE_HOME=/apps/oracle \
     WL_PKG=fmw_12.2.1.4.0_wls_lite_generic.jar \
@@ -41,7 +41,7 @@ RUN cd $ORACLE_HOME/weblogic-patches && \
 # Remove coherence extension to avoid runtime errors as we will exclude coherence from the built image
 RUN rm $ORACLE_HOME/wlserver/server/lib/management-services-ext/coherence-management-rest-extension.war
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:1.2.2
 
 ENV ORACLE_HOME=/apps/oracle
 


### PR DESCRIPTION
The new cert is included in ch-serverjre-1.2.2 which is needed as the previous cert is due to expire on 6th Aug.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1124