### PR TITLE
Update oraclelinux to 9 for WL14

### DIFF
--- a/ch-oraclelinux/Dockerfile
+++ b/ch-oraclelinux/Dockerfile
@@ -1,10 +1,11 @@
-FROM oraclelinux:7-slim
+FROM oraclelinux:9
 
-ENV LANG en_GB.UTF-8
+ENV LANG=en_GB.UTF-8
 
 RUN yum -y install iputils.x86_64 \
     vim-minimal \
     bind-utils \
     less \
     unzip; \
-    yum clean all
+    yum clean all && \
+    rm -fr /var/cache

--- a/ch-oraclelinux/version
+++ b/ch-oraclelinux/version
@@ -1,1 +1,1 @@
-choraclelinux-1.0
+choraclelinux-2.0


### PR DESCRIPTION
Changes the base image for ch-oraclelinux to oraclelinux:9

Also corrects syntax for ENV to avoid warnings seen locally, and removes the yum cache to reduce image size.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-835