### PR TITLE
Update ch-serverjre to use JDK 21

### DIFF
--- a/ch-serverjre/Dockerfile
+++ b/ch-serverjre/Dockerfile
@@ -1,7 +1,7 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:1.0.3 as builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.0 AS builder
 
-ENV JAVA_PKG=server-jre-8u???-linux-x64.tar.gz \
-    JAVA_HOME=/usr/java/jdk-8
+ENV JAVA_PKG=jdk-21-21.?.?_linux-x64_bin.tar.gz \
+    JAVA_HOME=/usr/java/jdk
 
 COPY $JAVA_PKG /tmp/jdk.tgz
 
@@ -14,13 +14,13 @@ COPY certs /tmp/certs
 
 RUN cd /tmp/certs && \
     for CERT_FILE in $(ls -1 *.pem); do \
-        $JAVA_HOME/bin/keytool -importcert -alias ${CERT_FILE%*.pem} -keystore $JAVA_HOME/jre/lib/security/cacerts -file ${CERT_FILE} -storepass changeit -noprompt; \
+        $JAVA_HOME/bin/keytool -importcert -alias ${CERT_FILE%*.pem} -keystore $JAVA_HOME/lib/security/cacerts -file ${CERT_FILE} -storepass changeit -noprompt; \
     done
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:1.0.3
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.0
 
-ENV JAVA_HOME=/usr/java/jdk-8 
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/usr/java/jdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 COPY --from=builder $JAVA_HOME $JAVA_HOME
 

--- a/ch-serverjre/version
+++ b/ch-serverjre/version
@@ -1,1 +1,1 @@
-chserverjre-1.2
+chserverjre-2.0


### PR DESCRIPTION
We need to use a later version of java for Weblogic 14.1.2.0, so this updates the ch-serverjre image to use Java 21.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-840