### PR TITLE
Use oraclelinux 8 as base image

### DIFF
--- a/ch-oraclelinux/Dockerfile
+++ b/ch-oraclelinux/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:9
+FROM oraclelinux:8
 
 ENV LANG=en_GB.UTF-8
 

--- a/ch-oraclelinux/Dockerfile
+++ b/ch-oraclelinux/Dockerfile
@@ -6,6 +6,6 @@ RUN yum -y install iputils.x86_64 \
     vim-minimal \
     bind-utils \
     less \
-    unzip; \
+    unzip && \
     yum clean all && \
     rm -fr /var/cache


### PR DESCRIPTION
Use version 8 of Oracle Linux instead of 9, and ensure the build fails if any installation via yum fails.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-835