### PR TITLE
Use ch-oraclelinux:2.0.1 as base

### DIFF
--- a/ch-serverjre/Dockerfile
+++ b/ch-serverjre/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.0 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.1 AS builder
 
 ENV JAVA_PKG=jdk-21-21.?.?_linux-x64_bin.tar.gz \
     JAVA_HOME=/usr/java/jdk
@@ -17,7 +17,7 @@ RUN cd /tmp/certs && \
         $JAVA_HOME/bin/keytool -importcert -alias ${CERT_FILE%*.pem} -keystore $JAVA_HOME/lib/security/cacerts -file ${CERT_FILE} -storepass changeit -noprompt; \
     done
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.1
 
 ENV JAVA_HOME=/usr/java/jdk
 ENV PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Updates the base image to use ch-oraclelinux:2.0.1 to pull in the move to Oracle Linux 8

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-840
