### PR TITLE
Update ch-apache Dockerfile for WL 14 apache plugin

### DIFF
--- a/ch-apache/Dockerfile
+++ b/ch-apache/Dockerfile
@@ -1,16 +1,45 @@
-FROM httpd:2.4
- 
-ENV PLUGIN_PATH=modules/WLSPlugin12.2.1.4.0
-ENV LD_LIBRARY_PATH=${HTTPD_PREFIX}/${PLUGIN_PATH}
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.1 AS builder
 
-# Copy the WebLogic Apache plugin module and libs onto the image   
-COPY lib ${PLUGIN_PATH}
+# Install build tools and dependencies
+RUN yum -y install gcc && \
+    yum -y install pcre-devel && \
+    yum -y install expat-devel && \
+    yum -y install openssl && \
+    yum -y install make
+
+# Copy over apache and apr source
+COPY *.tar.gz .
+
+# Extract source and build
+RUN tar -xzf httpd-2.*.tar.gz && \
+    tar -xzf apr-1.*.tar.gz && \
+    tar -xzf apr-util-1.*.tar.gz && \
+    rm *.tar.gz && \
+    cd httpd-2.* && \
+    mv ../apr-util-* srclib/apr-util && \
+    mv ../apr-* srclib/apr && \
+    ./configure --with-included-apr && \
+    make install
+
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
+
+ENV APACHE_HOME=/usr/local/apache2
+ENV PLUGINS_HOME=${APACHE_HOME}/modules/WLSPlugin14.1.2.0
+ENV LD_LIBRARY_PATH=${PLUGINS_HOME}
+
+# Copy the apache folder over
+COPY --from=builder ${APACHE_HOME} ${APACHE_HOME}
+
+# Copy the WebLogic Apache plugin lib folder onto the image   
+COPY lib ${PLUGINS_HOME}
+
+WORKDIR ${APACHE_HOME}
 
 # Use a custom start script to allow creation of exportedlogs/apache directory before startup
 COPY start-apache.sh bin/start-apache.sh
 RUN chmod +x bin/start-apache.sh
 
 # Reference the plugin module
-RUN sed -i '/mod_rewrite.so$/a LoadModule weblogic_module modules\/WLSPlugin12.2.1.4.0\/mod_wl_24.so' conf/httpd.conf
+RUN sed -i '/mod_rewrite.so$/a LoadModule weblogic_module modules\/WLSPlugin14.1.2.0\/mod_wl_24.so' conf/httpd.conf
 
-CMD ["/usr/local/apache2/bin/start-apache.sh"]
+CMD ["bin/start-apache.sh"]

--- a/ch-apache/version
+++ b/ch-apache/version
@@ -1,1 +1,1 @@
-chapache-1.1
+chapache-2.0


### PR DESCRIPTION
Updates the ch-apache Dockerfile to support the requirements of the WL14 apache plugin:

- reference new plugin zip for WL14
- builds newer version of apache and apr from source tarballs supplied by pipeline (httpd-2.4.65, apr-1.7.6 & apr-util-1.6.3 at the current time)
- uses ch-serverjre as base, as java is required for the plugin

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-885