### PR TITLE
Update ch-apache Dockerfile to make it work when not using buildkit

### DIFF
--- a/ch-apache/Dockerfile
+++ b/ch-apache/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y install gcc && \
     yum -y install make
 
 # Copy over apache and apr source
-COPY *.tar.gz .
+COPY *.tar.gz ./
 
 # Extract source and build
 RUN tar -xzf httpd-2.*.tar.gz && \


### PR DESCRIPTION
The ch-apache image build is failing due to the Concourse build not using build kit, so an adjustment is needed to the Dockerfile of adding a slash to a COPY command.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-885
