### PR TITLE
Correct the inventory location and directory ownership

### DIFF
--- a/ch-weblogic/Dockerfile
+++ b/ch-weblogic/Dockerfile
@@ -48,14 +48,14 @@ RUN mkdir -p /apps && \
     useradd -d $ORACLE_HOME -m -s /bin/bash weblogic
 
 USER weblogic
-COPY --from=builder $ORACLE_HOME/wlserver $ORACLE_HOME/wlserver
-COPY --from=builder $ORACLE_HOME/oracle_common $ORACLE_HOME/oracle_common
-COPY --from=builder $ORACLE_HOME/oraInst.loc $ORACLE_HOME/oraInst.loc
-COPY --from=builder $ORACLE_HOME/inventory $ORACLE_HOME/inventory
-COPY --from=builder $ORACLE_HOME/OPatch $ORACLE_HOME/OPatch
-COPY --from=builder $ORACLE_HOME/oui $ORACLE_HOME/oui
-COPY --from=builder $ORACLE_HOME/jlib $ORACLE_HOME/jlib
-COPY --from=builder $ORACLE_HOME/coherence $ORACLE_HOME/coherence
+COPY --from=builder --chown=weblogic $ORACLE_HOME/wlserver $ORACLE_HOME/wlserver
+COPY --from=builder --chown=weblogic $ORACLE_HOME/oracle_common $ORACLE_HOME/oracle_common
+COPY --from=builder --chown=weblogic $ORACLE_HOME/oraInst.loc $ORACLE_HOME/oraInst.loc
+COPY --from=builder --chown=weblogic $ORACLE_HOME/inventory $ORACLE_HOME/inventory
+COPY --from=builder --chown=weblogic $ORACLE_HOME/OPatch $ORACLE_HOME/OPatch
+COPY --from=builder --chown=weblogic $ORACLE_HOME/oui $ORACLE_HOME/oui
+COPY --from=builder --chown=weblogic $ORACLE_HOME/jlib $ORACLE_HOME/jlib
+COPY --from=builder --chown=weblogic $ORACLE_HOME/coherence $ORACLE_HOME/coherence
 
 WORKDIR $ORACLE_HOME
 CMD ["bash"]

--- a/ch-weblogic/oraInst.loc
+++ b/ch-weblogic/oraInst.loc
@@ -1,2 +1,2 @@
-inventory_loc=/apps/oracle/.inventory
+inventory_loc=/apps/oracle/inventory
 inst_group=weblogic


### PR DESCRIPTION
This is a fix to allow tools like OPatch inventory to be used from the command line in the final chips containers, and also allows the patches to be listed in the admin web console
<img width="899" height="581" alt="Screenshot 2025-12-30 at 15 42 32" src="https://github.com/user-attachments/assets/706753bd-7d43-43cf-81e2-9a9fbbcb9ef3" />

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-933