### PR TITLE
Bump version ch-serverjre for new weblogic root cert

### DIFF
--- a/ch-weblogic/Dockerfile
+++ b/ch-weblogic/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.2 AS builder
 
 ENV ORACLE_HOME=/apps/oracle \
     WL_PKG=fmw_14.1.2.0.0_wls.jar \
@@ -39,7 +39,7 @@ RUN cd $ORACLE_HOME/weblogic-patches && \
     done
 
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.2
 
 ENV ORACLE_HOME=/apps/oracle
 


### PR DESCRIPTION
Refer to ch-serverjre:2.0.2 to pull in updated weblogic certificate, which is now a self-signed custom certificate instead of the demo one supplied with weblogic.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1006