### PR TITLE
Reference ch-serverjre 2.0.3 to pull in JDK 21.0.9

### DIFF
--- a/ch-weblogic/Dockerfile
+++ b/ch-weblogic/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.2 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.3 AS builder
 
 ENV ORACLE_HOME=/apps/oracle \
     WL_PKG=fmw_14.1.2.0.0_wls.jar \
@@ -39,7 +39,7 @@ RUN cd $ORACLE_HOME/weblogic-patches && \
     done
 
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.2
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.3
 
 ENV ORACLE_HOME=/apps/oracle
 


### PR DESCRIPTION
The Oracle October 2025 patches include an updated version of the JDK (21.0.9), that has been built into ch-serverjre 2.0.3.

This PR updates the base image version to pull in that updated JDK.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1017