### PR TITLE
Adjust pattern to allow match of 21.0.10 version of JDK

### DIFF
--- a/ch-serverjre/Dockerfile
+++ b/ch-serverjre/Dockerfile
@@ -1,6 +1,6 @@
 FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-oraclelinux:2.0.1 AS builder
 
-ENV JAVA_PKG=jdk-21-21.?.?_linux-x64_bin.tar.gz \
+ENV JAVA_PKG=jdk-21-21.?.*_linux-x64_bin.tar.gz \
     JAVA_HOME=/usr/java/jdk
 
 COPY $JAVA_PKG /tmp/jdk.tgz


### PR DESCRIPTION
Adjust pattern in Dockerfile to cater for a minor version number greater than one digit.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1000