### PR TITLE
Reference ch-serverjre 2.0.4 to pull in JDK 21.0.10

### DIFF
--- a/ch-weblogic/Dockerfile
+++ b/ch-weblogic/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.3 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.4 AS builder
 
 ENV ORACLE_HOME=/apps/oracle \
     WL_PKG=fmw_14.1.2.0.0_wls.jar \
@@ -39,7 +39,7 @@ RUN cd $ORACLE_HOME/weblogic-patches && \
     done
 
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.3
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.4
 
 ENV ORACLE_HOME=/apps/oracle
 


### PR DESCRIPTION
Update the ch-weblogic build to include the latest JDK, as part of the Jan 2026 Oracle security fixes.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1000