### PR TITLE
Reference ch-serverjre 2.0.4 for JDK 21.0.10

### DIFF
--- a/ch-apache/Dockerfile
+++ b/ch-apache/Dockerfile
@@ -21,7 +21,7 @@ RUN tar -xzf httpd-2.*.tar.gz && \
     ./configure --with-included-apr && \
     make install
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre:2.0.4
 
 ENV APACHE_HOME=/usr/local/apache2
 ENV PLUGINS_HOME=${APACHE_HOME}/modules/WLSPlugin14.1.2.0


### PR DESCRIPTION
Use new ch-serverjre base image to pull in JDK 21.0.10

The new version of the ch-apache image will also be built with the latest WL Apache plugin, released in the Oracle Jan 2026 critical patch update.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1000